### PR TITLE
[PHP] RD 重構練習 by Jeff

### DIFF
--- a/php/src/GildedRose.php
+++ b/php/src/GildedRose.php
@@ -6,6 +6,28 @@ namespace GildedRose;
 
 final class GildedRose
 {
+    /** 預設時間流逝速度 */
+    const DATE_FLIES = 1;
+    /** 預設商品過期流逝倍率 */
+    const QUALITY_OVER_TERM_MAGNIFICATION = 2;
+    /** 預設商品價值上限 */
+    const QUALITY_DEFAULT_RANGE = [
+        'default_up' => 50,
+        'default_down' => 0,
+        'Sulfuras, Hand of Ragnaros' => 80
+    ];
+    /** 預設商品流逝價值 */
+    const QUALITY_PASSES_LESS = [
+        'default' => -1,
+        'Conjured' => -2
+    ];
+    /** 預設商品增值價值 */
+    const QUALITY_PASSES_INCREASE = [
+        'default' => 1,
+        'Backstage_passes_less_10' => 2,
+        'Backstage_passes_less_5' => 3,
+    ];
+
     /**
      * @var Item[]
      */
@@ -19,50 +41,50 @@ final class GildedRose
     public function updateQuality(): void
     {
         foreach ($this->items as $item) {
-            if ($item->name != 'Aged Brie' and $item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                if ($item->quality > 0) {
-                    if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                        $item->quality = $item->quality - 1;
-                    }
-                }
-            } else {
-                if ($item->quality < 50) {
-                    $item->quality = $item->quality + 1;
-                    if ($item->name == 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->sellIn < 11) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                        if ($item->sellIn < 6) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                $item->sellIn = $item->sellIn - 1;
-            }
-
-            if ($item->sellIn < 0) {
-                if ($item->name != 'Aged Brie') {
-                    if ($item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->quality > 0) {
-                            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                                $item->quality = $item->quality - 1;
-                            }
-                        }
+            $item->sellIn = $item->sellIn - self::DATE_FLIES;
+            switch ($item->name) {
+                case 'Aged Brie': // 永不過期，且隨著時間品質提高
+                    if ($item->sellIn >= 0) {
+                        $item->quality += self::QUALITY_PASSES_INCREASE['default'];
                     } else {
-                        $item->quality = $item->quality - $item->quality;
+                        $item->quality += self::QUALITY_PASSES_INCREASE['default'] * self::QUALITY_OVER_TERM_MAGNIFICATION;
                     }
-                } else {
-                    if ($item->quality < 50) {
-                        $item->quality = $item->quality + 1;
+                    break;
+                case 'Sulfuras, Hand of Ragnaros': // 永不過期，品質不變
+                    $item->sellIn += self::DATE_FLIES;
+                    break;
+                case 'Backstage passes to a TAFKAL80ETC concert': // 隨著到期日越接近價值越高
+                    if ($item->sellIn < 0) {
+                        $item->quality = self::QUALITY_DEFAULT_RANGE["default_down"];
+                    } elseif (5 > $item->sellIn && $item->sellIn >= 0) {
+                        $item->quality += self::QUALITY_PASSES_INCREASE['Backstage_passes_less_5'];
+                    } elseif (10 > $item->sellIn && $item->sellIn >= 5) {
+                        $item->quality += self::QUALITY_PASSES_INCREASE['Backstage_passes_less_10'];
+                    } else {
+                        $item->quality += self::QUALITY_PASSES_INCREASE['default'];
                     }
-                }
+                    break;
+                case 'Conjured': // 品質下降比正常速度快一倍
+                    if ($item->sellIn < 0) {
+                        $item->quality += self::QUALITY_PASSES_LESS['Conjured'] * self::QUALITY_OVER_TERM_MAGNIFICATION;
+                    } else {
+                        $item->quality += self::QUALITY_PASSES_LESS['Conjured'];
+                    }
+
+                    break;
+                default:
+                    if ($item->sellIn < 0) {
+                        $item->quality += self::QUALITY_PASSES_LESS['default'] * self::QUALITY_OVER_TERM_MAGNIFICATION;
+                    } else {
+                        $item->quality += self::QUALITY_PASSES_LESS['default'];
+                    }
+
+                    break;
+            }
+            if ($item->quality >= self::QUALITY_DEFAULT_RANGE['default_up'] && $item->name != 'Sulfuras, Hand of Ragnaros') {
+                $item->quality = self::QUALITY_DEFAULT_RANGE['default_up'];
+            } elseif ($item->quality < self::QUALITY_DEFAULT_RANGE['default_down']) {
+                $item->quality = self::QUALITY_DEFAULT_RANGE['default_down'];
             }
         }
     }

--- a/php/src/GildedRose.php
+++ b/php/src/GildedRose.php
@@ -83,6 +83,8 @@ final class GildedRose
             }
             if ($item->quality >= self::QUALITY_DEFAULT_RANGE['default_up'] && $item->name != 'Sulfuras, Hand of Ragnaros') {
                 $item->quality = self::QUALITY_DEFAULT_RANGE['default_up'];
+            } elseif ($item->quality >= self::QUALITY_DEFAULT_RANGE['Sulfuras, Hand of Ragnaros'] && $item->name == 'Sulfuras, Hand of Ragnaros') {
+                $item->quality = self::QUALITY_DEFAULT_RANGE['Sulfuras, Hand of Ragnaros'];
             } elseif ($item->quality < self::QUALITY_DEFAULT_RANGE['default_down']) {
                 $item->quality = self::QUALITY_DEFAULT_RANGE['default_down'];
             }

--- a/php/tests/GildedRoseTest.php
+++ b/php/tests/GildedRoseTest.php
@@ -329,4 +329,63 @@ class GildedRoseTest extends TestCase
         $this->assertSame(-2, $items[0]->sellIn);
         $this->assertSame(0, $items[0]->quality);
     }
+
+    //-----------------
+    // Conjured item
+    //-----------------
+    public function testUpdatesConjuredItemsBeforeSellDate(): void
+    {
+        // arrange
+        $items = [new Item('Conjured', 5, 10)];
+        $app = new GildedRose($items);
+
+        // act
+        $app->updateQuality();
+
+        // assert
+        $this->assertSame(4, $items[0]->sellIn);
+        $this->assertSame(8, $items[0]->quality);
+    }
+
+    public function testUpdatesConjuredItemsOnSellDate(): void
+    {
+        // arrange
+        $items = [new Item('Conjured', 0, 10)];
+        $app = new GildedRose($items);
+
+        // act
+        $app->updateQuality();
+
+        // assert
+        $this->assertSame(-1, $items[0]->sellIn);
+        $this->assertSame(6, $items[0]->quality);
+    }
+
+    public function testUpdatesConjuredItemsAfterSellDate(): void
+    {
+        // arrange
+        $items = [new Item('Conjured', -5, 10)];
+        $app = new GildedRose($items);
+
+        // act
+        $app->updateQuality();
+
+        // assert
+        $this->assertSame(-6, $items[0]->sellIn);
+        $this->assertSame(6, $items[0]->quality);
+    }
+
+    public function testUpdatesConjuredItemsWithAQualityOf0(): void
+    {
+        // arrange
+        $items = [new Item('Conjured', 5, 0)];
+        $app = new GildedRose($items);
+
+        // act
+        $app->updateQuality();
+
+        // assert
+        $this->assertSame(4, $items[0]->sellIn);
+        $this->assertSame(0, $items[0]->quality);
+    }
 }

--- a/php/tests/GildedRoseTest.php
+++ b/php/tests/GildedRoseTest.php
@@ -215,6 +215,20 @@ class GildedRoseTest extends TestCase
         $this->assertSame(10, $items[0]->quality);
     }
 
+    public function testUpdatesSulfurasItemsBeforeSellDateAndQuality80(): void
+    {
+        // arrange
+        $items = [new Item('Sulfuras, Hand of Ragnaros', 5, 80)];
+        $app = new GildedRose($items);
+
+        // act
+        $app->updateQuality();
+
+        // assert
+        $this->assertSame(5, $items[0]->sellIn);
+        $this->assertSame(80, $items[0]->quality);
+    }
+
     //-----------------
     // Backstage Pass
     //-----------------


### PR DESCRIPTION
- 重構商品頁邏輯
  - 將魔術數字改用常數取代，並重新撰寫邏輯，應該會比較方便之後商品擴充或修改
- 測試
  - 主要是取用normal的測試案例來做調整